### PR TITLE
destructure ioredis arguments array

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ class RedisGraph extends Redis {
       super(graphName)
       this.graphName = graphName.graphName
     } else {
-      super(args)
+      super(...args)
       this.graphName = graphName
     }
 


### PR DESCRIPTION
This was probably an oversight. Now, you're able to use constructors with URLs like `new RedisGraph('foo', 'redis://127.0.0.1:1234/')`.